### PR TITLE
Soporte para 3 players !

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -26,11 +26,6 @@ window/stretch/aspect="ignore"
 
 [input]
 
-p1press={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
-]
-}
 p1left={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
@@ -61,9 +56,34 @@ p1jump={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"echo":false,"script":null)
 ]
 }
+p1press={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
+]
+}
 p2jump={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+p3left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":74,"key_label":0,"unicode":106,"echo":false,"script":null)
+]
+}
+p3right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":76,"key_label":0,"unicode":108,"echo":false,"script":null)
+]
+}
+p3jump={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":73,"key_label":0,"unicode":105,"echo":false,"script":null)
+]
+}
+p3press={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":75,"key_label":0,"unicode":107,"echo":false,"script":null)
 ]
 }
 

--- a/scenes/levels/Level1.tscn
+++ b/scenes/levels/Level1.tscn
@@ -3334,13 +3334,13 @@ unique_name_in_owner = true
 
 [node name="Rata1" parent="Jugadores" instance=ExtResource("2_sjj3d")]
 z_index = 1
-position = Vector2(792, 758)
+position = Vector2(79, 503)
 player = 1
 skin = ExtResource("6_6wxrj")
 
 [node name="Rata2" parent="Jugadores" instance=ExtResource("2_sjj3d")]
 z_index = 1
-position = Vector2(1134, 760)
+position = Vector2(985, 1009)
 collision_layer = 2
 collision_mask = 2
 player = 2

--- a/scenes/ui/Title.tscn
+++ b/scenes/ui/Title.tscn
@@ -1,38 +1,48 @@
-[gd_scene load_steps=3 format=3 uid="uid://s0fhny31o8ob"]
+[gd_scene load_steps=4 format=3 uid="uid://s0fhny31o8ob"]
 
 [ext_resource type="Texture2D" uid="uid://65g4smmecung" path="res://assets/menu-carga.png" id="1_4l63k"]
+[ext_resource type="Script" path="res://scripts/levels/Title.gd" id="1_tcr5g"]
 [ext_resource type="AudioStream" uid="uid://dp6eyhj63xeoe" path="res://assets/jajejijoju.wav" id="2_4640q"]
 
-[node name="GameNext" type="Control"]
+[node name="Title" type="Control"]
 process_mode = 3
 z_index = 5
 layout_mode = 3
 anchors_preset = 0
+script = ExtResource("1_tcr5g")
 
 [node name="TextureRect" type="TextureRect" parent="."]
 layout_mode = 0
-offset_right = 40.0
-offset_bottom = 40.0
+offset_right = 1920.0
+offset_bottom = 1080.0
 texture = ExtResource("1_4l63k")
 
-[node name="ColorRect" type="ColorRect" parent="."]
+[node name="2Players" type="Button" parent="."]
 layout_mode = 0
-offset_left = 1226.0
-offset_top = 830.0
-offset_right = 1266.0
-offset_bottom = 870.0
-scale = Vector2(12.5211, 3.84)
-color = Color(1, 0.8, 0, 1)
-
-[node name="Comenzar" type="Button" parent="."]
-modulate = Color(0, 0.101961, 0.894118, 1)
-layout_mode = 0
-offset_left = 1224.0
-offset_top = 827.0
-offset_right = 1724.0
+offset_left = 1173.0
+offset_top = 823.0
+offset_right = 1484.0
 offset_bottom = 983.0
-theme_override_font_sizes/font_size = 40
-text = "Comenzar"
+theme_override_colors/font_color = Color(0, 0, 1, 1)
+theme_override_colors/font_outline_color = Color(0.996078, 0.882353, 0, 1)
+theme_override_constants/outline_size = 33
+theme_override_font_sizes/font_size = 55
+text = "2
+Players"
+flat = true
+
+[node name="3Players" type="Button" parent="."]
+layout_mode = 0
+offset_left = 1515.0
+offset_top = 827.0
+offset_right = 1822.0
+offset_bottom = 987.0
+theme_override_colors/font_color = Color(0, 0, 1, 1)
+theme_override_colors/font_outline_color = Color(0.996078, 0.882353, 0, 1)
+theme_override_constants/outline_size = 33
+theme_override_font_sizes/font_size = 55
+text = "3
+Players"
 flat = true
 
 [node name="Label" type="Label" parent="."]
@@ -51,3 +61,32 @@ vertical_alignment = 1
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("2_4640q")
 autoplay = true
+
+[node name="ComenzarButton" type="Control" parent="."]
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="ColorRect" type="ColorRect" parent="ComenzarButton"]
+layout_mode = 0
+offset_left = 1226.0
+offset_top = 830.0
+offset_right = 1266.0
+offset_bottom = 870.0
+scale = Vector2(12.5211, 3.84)
+color = Color(1, 0.8, 0, 1)
+
+[node name="Comenzar" type="Button" parent="ComenzarButton"]
+modulate = Color(0, 0.101961, 0.894118, 1)
+layout_mode = 0
+offset_left = 1224.0
+offset_top = 827.0
+offset_right = 1724.0
+offset_bottom = 983.0
+theme_override_font_sizes/font_size = 40
+text = "Comenzar"
+flat = true
+
+[connection signal="pressed" from="2Players" to="." method="_on_2players_pressed"]
+[connection signal="pressed" from="3Players" to="." method="_on_3players_pressed"]
+[connection signal="pressed" from="ComenzarButton/Comenzar" to="." method="_on_comenzar_pressed"]

--- a/scripts/control/manager.gd
+++ b/scripts/control/manager.gd
@@ -3,7 +3,7 @@ extends Node2D
 var spawns = []
 var gases = []
 var ratas = []
-
+var player_count : int
 var Nivel: Node2D
 
 func is_gas(child):
@@ -86,10 +86,14 @@ func perdi():
 
 func cargar_titulo():
 	var Title = preload("res://scenes/ui/Title.tscn").instantiate()
-	Title.find_child("Comenzar").pressed.connect(cargar_nivel)
+	Title.connect('start',set_player_count)
 	Nivel = Node2D.new()
 	add_child(Nivel) # hack
 	Nivel.add_child(Title)
+	
+func set_player_count(c):
+	player_count = c
+	cargar_nivel()
 
 func cargar_nivel():
 	spawns = []; gases = []; ratas = []
@@ -98,6 +102,7 @@ func cargar_nivel():
 		remove_child(Nivel)
 
 	Nivel = load("res://scenes/levels/Level" + str(NIVEL) + ".tscn").instantiate()
+	Nivel.player_count = player_count
 	add_child(Nivel)
 	get_tree().paused = false
 

--- a/scripts/levels/Title.gd
+++ b/scripts/levels/Title.gd
@@ -1,0 +1,18 @@
+extends Control
+signal start(players_count)
+
+func _ready():
+	$ComenzarButton.visible = true
+	$'2Players'.visible = false
+	$'3Players'.visible = false
+	
+func _on_comenzar_pressed():
+	$ComenzarButton.visible = false
+	$'2Players'.visible = true
+	$'3Players'.visible = true
+	
+func _on_2players_pressed():
+	start.emit(2)
+	
+func _on_3players_pressed():
+	start.emit(3)

--- a/scripts/levels/level1.gd
+++ b/scripts/levels/level1.gd
@@ -4,3 +4,78 @@ extends Node2D
 @onready var Spawn = %Spawn
 @onready var Jugadores = %Jugadores
 @onready var Jefe = %JaJa
+@export var player_count : int
+
+func _ready():
+	if (player_count >= 3) :
+		var skin3 = preload("res://assets/rata.png")
+		var rata3 = preload("res://scenes/prefabs/Rata.tscn").instantiate()
+		rata3.position = Vector2(1830,500)
+		rata3.player = 3
+		rata3.skin = skin3
+		Jugadores.add_child(rata3)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+
+
+
+
+
+
+
+
+
+

--- a/scripts/levels/level2.gd
+++ b/scripts/levels/level2.gd
@@ -4,3 +4,13 @@ extends Node2D
 @onready var Spawn = %Spawn
 @onready var Jugadores = %Jugadores
 @onready var Jefe = %JeJe
+@export var player_count : int
+
+func _ready():
+	if (player_count >= 3) :
+		var skin3 = preload("res://assets/rata.png")
+		var rata3 = preload("res://scenes/prefabs/Rata.tscn").instantiate()
+		rata3.position = Vector2(1830,500)
+		rata3.player = 3
+		rata3.skin = skin3
+		Jugadores.add_child(rata3)

--- a/scripts/levels/level3.gd
+++ b/scripts/levels/level3.gd
@@ -4,3 +4,13 @@ extends Node2D
 @onready var Spawn = %Spawn
 @onready var Jugadores = %Jugadores
 @onready var Jefe = %JiJi
+@export var player_count : int
+
+func _ready():
+	if (player_count >= 3) :
+		var skin3 = preload("res://assets/rata.png")
+		var rata3 = preload("res://scenes/prefabs/Rata.tscn").instantiate()
+		rata3.position = Vector2(1830,500)
+		rata3.player = 3
+		rata3.skin = skin3
+		Jugadores.add_child(rata3)

--- a/scripts/levels/level4.gd
+++ b/scripts/levels/level4.gd
@@ -4,3 +4,13 @@ extends Node2D
 @onready var Spawn = %Spawn
 @onready var Jugadores = %Jugadores
 @onready var Jefe = %JoJo
+@export var player_count : int
+
+func _ready():
+	if (player_count >= 3) :
+		var skin3 = preload("res://assets/rata.png")
+		var rata3 = preload("res://scenes/prefabs/Rata.tscn").instantiate()
+		rata3.position = Vector2(1830,500)
+		rata3.player = 3
+		rata3.skin = skin3
+		Jugadores.add_child(rata3)

--- a/scripts/levels/level5.gd
+++ b/scripts/levels/level5.gd
@@ -4,3 +4,13 @@ extends Node2D
 @onready var Spawn = %Spawn
 @onready var Jugadores = %Jugadores
 @onready var Jefe = %JuJu
+@export var player_count : int
+
+func _ready():
+	if (player_count >= 3) :
+		var skin3 = preload("res://assets/rata.png")
+		var rata3 = preload("res://scenes/prefabs/Rata.tscn").instantiate()
+		rata3.position = Vector2(1830,500)
+		rata3.player = 3
+		rata3.skin = skin3
+		Jugadores.add_child(rata3)


### PR DESCRIPTION
Habría que ajustar la posición de spawn de la Rata3 para cada nivel, esta muy verde y en algunos spawnea cayendo, pero es jugable. 

También veo muy viable la posibilidad de agregar sistema de skins seteandolas en los scripts de cada nivel según una variable global del Manager, con un sub-menu antes de empezar, donde tambien se podrían elegir controles (soporte para joystick y mapeos de teclado custom) , aunque esto último es más aburrido y al pedo. Pero todo eso escapa los alcances de este PR
